### PR TITLE
LV_LVGL_H_INCLUDE_SIMPLE and lv_colorwheel_get_rgb updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Components (widgets) for LVGL
 
-This repository contains extra widgets for LVGL to complemte the built in ones. If you have created a custom widgets for LVGL this repostiroy is great place to share it with other. 
+This repository contains extra widgets for LVGL to complement the built in ones. If you have created a custom widgets for LVGL this repository is a great place to share it with others. 
 
 ## Contributing
 Just send a pull request with your widget or improvement.

--- a/src/lv_calendar/lv_calendar.h
+++ b/src/lv_calendar/lv_calendar.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/src/lv_calendar/lv_calendar_header_arrow.h
+++ b/src/lv_calendar/lv_calendar_header_arrow.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/src/lv_colorwheel/lv_colorwheel.c
+++ b/src/lv_colorwheel/lv_colorwheel.c
@@ -696,8 +696,7 @@ static lv_color_t angle_to_mode_color(lv_obj_t * colorwheel, uint16_t angle)
             color = lv_color_hsv_to_rgb(angle, ext->hsv.s, ext->hsv.v);
             break;
         case LV_COLORWHEEL_MODE_SATURATION:
-            if(angle < 180) color = lv_color_hsv_to_rgb(ext->hsv.h, (angle * 100) / 360, ext->hsv.v);
-            else color = LV_COLOR_BLACK;
+            color = lv_color_hsv_to_rgb(ext->hsv.h, (angle * 100) / 360, ext->hsv.v);
             break;
         case LV_COLORWHEEL_MODE_VALUE:
             color = lv_color_hsv_to_rgb(ext->hsv.h, ext->hsv.s, (angle * 100) / 360);

--- a/src/lv_colorwheel/lv_colorwheel.h
+++ b/src/lv_colorwheel/lv_colorwheel.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES
@@ -122,7 +126,7 @@ lv_color_hsv_t lv_colorwheel_get_hsv(lv_obj_t * colorwheel);
  * @param colorwheel pointer to color picker object
  * @return current selected color
  */
-lv_color_t lv_colorwheel_get_color(lv_obj_t * colorwheel);
+lv_color_t lv_colorwheel_get_rgb(lv_obj_t * colorwheel);
 
 /**
  * Get if the color mode is changed on long press on center

--- a/src/lv_keyboard/lv_keyboard.h
+++ b/src/lv_keyboard/lv_keyboard.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*Testing of dependencies*/
 #if LV_USE_BTNMATRIX == 0

--- a/src/lv_led/lv_led.h
+++ b/src/lv_led/lv_led.h
@@ -13,8 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
-
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/src/lv_list/lv_list.h
+++ b/src/lv_list/lv_list.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/src/lv_msgbox/lv_msgbox.h
+++ b/src/lv_msgbox/lv_msgbox.h
@@ -28,8 +28,6 @@ extern "C" {
 #error "lv_mbox: lv_label is required. Enable it in lv_conf.h (LV_USE_LABEL  1) "
 #endif
 
-#include "lvgl/lvgl.h"
-
 /*********************
  *      DEFINES
  *********************/

--- a/src/lv_msgbox/lv_msgbox.h
+++ b/src/lv_msgbox/lv_msgbox.h
@@ -13,10 +13,13 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*Testing of dependencies*/
-
 #if LV_USE_BTNMATRIX == 0
 #error "lv_mbox: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNMATRIX  1) "
 #endif

--- a/src/lv_spinbox/lv_spinbox.h
+++ b/src/lv_spinbox/lv_spinbox.h
@@ -13,8 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
-
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*Testing of dependencies*/
 #if LV_USE_TEXTAREA == 0

--- a/src/lv_spinner/lv_spinner.h
+++ b/src/lv_spinner/lv_spinner.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*Testing of dependencies*/
 #if LV_USE_ARC == 0

--- a/src/lv_tabview/lv_tabview.h
+++ b/src/lv_tabview/lv_tabview.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/src/lv_tileview/lv_tileview.h
+++ b/src/lv_tileview/lv_tileview.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "lvgl/lvgl.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES

--- a/src/lv_win/lv_win.h
+++ b/src/lv_win/lv_win.h
@@ -13,7 +13,11 @@ extern "C" {
 /*********************
  *      INCLUDES
  *********************/
-#include "../../lv_components.h"
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "../lvgl/lvgl.h"
+#endif
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
Improvement and small fix for the lv_components according to my [first v8 remarks](https://github.com/lvgl/lvgl/issues/1852#issuecomment-735888043):

- Use LV_LVGL_H_INCLUDE_SIMPLE when defined
- Rename lv_colorwheel_get_color to lv_colorwheel_get_rgb in the header file
- Fix typo in README